### PR TITLE
fix(deps): update shell-quote to 1.8.4

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -11388,9 +11388,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
## Summary
- Update dashboard package lock to resolve Dependabot alert #83 for shell-quote (GHSA-w7jw-789q-3m8p / CVE-2026-9277)
- Move transitive shell-quote from 1.8.3 to patched 1.8.4

## Verification
- npm.cmd ls shell-quote --all
- npm.cmd install --ignore-scripts